### PR TITLE
fix(crudable): drop ignored $id arg from Eloquent delete/forceDelete

### DIFF
--- a/src/Crudable/Crudable.php
+++ b/src/Crudable/Crudable.php
@@ -176,9 +176,9 @@ trait Crudable
     public function delete($id, $hardDelete = false)
     {
         if ($hardDelete) {
-            return $this->model->withTrashed()->find($id)->forceDelete($id);
+            return $this->model->withTrashed()->find($id)->forceDelete();
         }
-        return $this->model->find($id)->delete($id);
+        return $this->model->find($id)->delete();
     }
 
     /**

--- a/tests/Unit/CrudableTraitTest.php
+++ b/tests/Unit/CrudableTraitTest.php
@@ -92,6 +92,27 @@ class CrudableTraitTest extends TestCase
         $this->assertSoftDeleted('stub_models', ['id' => $model->id]);
     }
 
+    public function test_delete_hard_deletes_record(): void
+    {
+        $model = StubModel::create(['name' => 'ToHardDelete']);
+        $service = $this->getService();
+        $service->delete($model->id, true);
+
+        $this->assertDatabaseMissing('stub_models', ['id' => $model->id]);
+    }
+
+    public function test_delete_hard_deletes_already_trashed_record(): void
+    {
+        $model = StubModel::create(['name' => 'ToForceDelete']);
+        $model->delete();
+        $this->assertSoftDeleted('stub_models', ['id' => $model->id]);
+
+        $service = $this->getService();
+        $service->delete($model->id, true);
+
+        $this->assertDatabaseMissing('stub_models', ['id' => $model->id]);
+    }
+
     public function test_restore_undeletes_record(): void
     {
         $model = StubModel::create(['name' => 'ToRestore']);


### PR DESCRIPTION
## Summary

`Crudable::delete($id, $hardDelete)` was passing `$id` to the instance methods `Eloquent\Model::delete()` and `forceDelete()`, which take no arguments. The argument was silently ignored — the model was already loaded via `find($id)` on the previous line — so behavior was correct by accident, but the call signature was misleading and would break under static analysis at higher PHPStan levels.

## Changes

- `src/Crudable/Crudable.php` — remove the bogus `$id` arg from both `delete()` and `forceDelete()` calls
- `tests/Unit/CrudableTraitTest.php` — add regression coverage for the hard-delete and soft-delete-then-force-delete paths, neither of which was previously exercised

## Test plan

- [x] `vendor/bin/phpunit` — 36/36 passing
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — clean
- [x] Local matrix: PHP 8.2/8.3/8.4 × Laravel 11/12/13 (8 cells, all green)

## Target

This is a patch fix for the `6.x` maintenance line, intended for the upcoming `6.2.1` release.